### PR TITLE
chore: update example gitignore

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,9 +1,5 @@
 .terraform/
-terraform.tfstate
-terraform.tfstate.backup
+terraform.tfstate*
 *.auto.tfvars
 
-files/*
-!files/.gitkeep
-
-.env
+files/

--- a/example/Makefile
+++ b/example/Makefile
@@ -27,4 +27,4 @@ port-forward:
 	bash files/registry-port-forward.sh
 
 clean:
-	rm -Rf files/* .terraform/ terraform.tfstate* env.auto.tfvars
+	rm -Rf files/ .terraform/ terraform.tfstate* env.auto.tfvars


### PR DESCRIPTION
- The `files` directory is created automatically, no need to .gitkeep it.
- The `.env` file is not used anymore.
- Improve gitignore file.